### PR TITLE
Disable barometer if not detected

### DIFF
--- a/app/src/main/java/com/example/cloud/sensors/MovementSensor.java
+++ b/app/src/main/java/com/example/cloud/sensors/MovementSensor.java
@@ -42,15 +42,27 @@ public class MovementSensor {
         this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
         this.sensor = sensorManager.getDefaultSensor(sensorType);
 
-        this.sensorInfo = new SensorInfo(
-                sensor.getName(),
-                sensor.getVendor(),
-                sensor.getResolution(),
-                sensor.getPower(),
-                sensor.getVersion(),
-                sensor.getType()
-        );
-        System.err.println(sensorInfo);
+        if (sensor != null) {
+            this.sensorInfo = new SensorInfo(
+                    sensor.getName(),
+                    sensor.getVendor(),
+                    sensor.getResolution(),
+                    sensor.getPower(),
+                    sensor.getVersion(),
+                    sensor.getType()
+            );
+            System.err.println(sensorInfo);
+        } else {
+            this.sensorInfo = new SensorInfo(
+                    "Not available",
+                    "-",
+                    -1.0f,
+                    0.0f,
+                    0,
+                    0
+            );
+
+        }
     }
 
 }

--- a/app/src/main/java/com/example/cloud/sensors/SensorFusion.java
+++ b/app/src/main/java/com/example/cloud/sensors/SensorFusion.java
@@ -182,6 +182,7 @@ public class SensorFusion implements SensorEventListener, Observer {
         this.angularVelocity = new float[3];
         this.orientation = new float[3];
         this.rotation = new float[4];
+        this.rotation[3] = 1.0f;
         this.R = new float[9];
         // If the gyro needs to be initialised
         this.initState = true;
@@ -941,10 +942,10 @@ public class SensorFusion implements SensorEventListener, Observer {
                     .setGyrY(angularVelocity[1])
                     .setGyrZ(angularVelocity[2])
                     .setGyrZ(angularVelocity[2])
-                    .setRotationVectorW(rotation[0])
-                    .setRotationVectorX(rotation[1])
-                    .setRotationVectorY(rotation[2])
-                    .setRotationVectorZ(rotation[3])
+                    .setRotationVectorX(rotation[0])
+                    .setRotationVectorY(rotation[1])
+                    .setRotationVectorZ(rotation[2])
+                    .setRotationVectorW(rotation[3])
                     .setStepCount(stepCounter))
                     .addPositionData(Traj.Position_Sample.newBuilder()
                             .setMagX(magneticField[0])
@@ -956,13 +957,15 @@ public class SensorFusion implements SensorEventListener, Observer {
             if (counter == 99) {
                 counter = 0;
                 // Store pressure and light data
-                trajectory.addPressureData(Traj.Pressure_Sample.newBuilder()
-                        .setPressure(pressure)
-                        .setRelativeTimestamp(android.os.SystemClock.uptimeMillis()-bootTime))
-                        .addLightData(Traj.Light_Sample.newBuilder()
-                                .setLight(light)
-                                .setRelativeTimestamp(android.os.SystemClock.uptimeMillis()-bootTime)
-                                .build());
+                if (barometerSensor != null) {
+                    trajectory.addPressureData(Traj.Pressure_Sample.newBuilder()
+                                    .setPressure(pressure)
+                                    .setRelativeTimestamp(android.os.SystemClock.uptimeMillis() - bootTime))
+                            .addLightData(Traj.Light_Sample.newBuilder()
+                                    .setLight(light)
+                                    .setRelativeTimestamp(android.os.SystemClock.uptimeMillis() - bootTime)
+                                    .build());
+                }
 
                 // Divide the timer for storing AP data every 5 seconds
                 if (secondCounter == 4) {

--- a/app/src/main/java/com/example/cloud/sensors/SensorFusion.java
+++ b/app/src/main/java/com/example/cloud/sensors/SensorFusion.java
@@ -957,7 +957,7 @@ public class SensorFusion implements SensorEventListener, Observer {
             if (counter == 99) {
                 counter = 0;
                 // Store pressure and light data
-                if (barometerSensor != null) {
+                if (barometerSensor.sensor != null) {
                     trajectory.addPressureData(Traj.Pressure_Sample.newBuilder()
                                     .setPressure(pressure)
                                     .setRelativeTimestamp(android.os.SystemClock.uptimeMillis() - bootTime))


### PR DESCRIPTION
Fixes an app crash if the phone doesn't have a barometer, also fixes the initial rotation vector and corrects the order of the vector when creating the trajectory file