### PR TITLE
Kalman Filter for predicting "null" value in weibergMinMax finding Collections.max/min(accelMagnitude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ Indoor poistioning data collection application created for the University of Edi
 
 ### New contributors
 - Francisco Zampella (fzampella-huawei)
+
+### Note by Group2
+- Bug/Reason/Fix
+
+1.  B: Map api key not working
+    R: Var for storaging api key in secret.properties file is not called
+    F: In app level build.gradle (:app), "secret" part is uncommented, and moved inside of android block.
+2.  B: Crush for Android 12+ (?) version
+    R: In Android, java, "PdrProcessing.java", block "weibergMinMax" (after line 222), "Collections.max(accelMagnitude)" causing crash.
+    in "Collections.max(accelMagnitude)", accelMagnitude could be undefined, causing error for Collections.max()
+    F: Add if statement to give accelMagnitude 0 value if it is undefined.
+
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,21 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    secrets {
+//    // Optionally specify a different file name containing your secrets.
+//    // The plugin defaults to "local.properties"
+    propertiesFileName = "secrets.properties"
+//
+//    // A properties file containing default secret values. This file can be
+//    // checked in version control.
+    defaultPropertiesFileName = "local.defaults.properties"
+//
+//    // Configure which keys should be ignored by the plugin by providing regular expressions.
+//    // "sdk.dir" is ignored by default.
+    ignoreList.add("keyToIgnore") // Ignore the key "keyToIgnore"
+    ignoreList.add("sdk.*")       // Ignore all keys matching the regexp "sdk.*"
+    }
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,10 @@
         android:theme="@style/Theme.Cloud">
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/google_maps_key"/>
+            android:value="${MAPS_API_KEY}"/>
+        <meta-data
+            android:name="com.openpositioning.master_key"
+            android:value="${OPENPOSITIONING_API_KEY}$"/>
         <activity
             android:name="com.openpositioning.PositionMe.MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/openpositioning/PositionMe/MainActivity.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/MainActivity.java
@@ -255,7 +255,8 @@ public class MainActivity extends AppCompatActivity implements Observer {
         }
         else{
             // Check other permissions if present
-            askStoragePermission();
+            //askStoragePermission();
+            askMotionPermissions();
         }
     }
 

--- a/app/src/main/java/com/openpositioning/PositionMe/PdrProcessing.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/PdrProcessing.java
@@ -3,6 +3,7 @@ package com.openpositioning.PositionMe;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.hardware.SensorManager;
+import android.util.Log;
 
 import androidx.preference.PreferenceManager;
 
@@ -220,14 +221,24 @@ public class PdrProcessing {
      * @return                  float stride length in meters.
      */
     private float weibergMinMax(List<Double> accelMagnitude) {
-        double maxAccel = Collections.max(accelMagnitude);
-        double minAccel = Collections.min(accelMagnitude);
-        float bounce = (float) Math.pow((maxAccel-minAccel), 0.25);
-        if(this.settings.getBoolean("overwrite_constants", false)) {
-            return bounce * Float.parseFloat(settings.getString("weiberg_k", "0.934")) * 2;
-        }
-        return bounce*K*2;
+
+        if (accelMagnitude.isEmpty()) {
+            Log.w("PdrProcessing", "List is empty in weibergMinMax()");
+            return 0.0f;
+        }else {
+
+
+
+
+            double maxAccel = Collections.max(accelMagnitude);
+            double minAccel = Collections.min(accelMagnitude);
+            float bounce = (float) Math.pow((maxAccel-minAccel), 0.25);
+            if(this.settings.getBoolean("overwrite_constants", false)) {
+                return bounce * Float.parseFloat(settings.getString("weiberg_k", "0.934")) * 2;
+            }
+            return bounce*K*2;}
     }
+
 
     /**
      * Get the current X and Y coordinates from the PDR processing class.

--- a/app/src/main/java/com/openpositioning/PositionMe/PdrProcessing.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/PdrProcessing.java
@@ -15,43 +15,50 @@ import java.util.List;
 import java.util.OptionalDouble;
 
 /**
- * Processes data recorded in the {@link SensorFusion} class and calculates live PDR estimates.
- * It calculates the position from the steps and directions detected, using either estimated values
- * (eg. stride length from the Weiberg algorithm) or provided constants, calculates the elevation
- * and attempts to estimate the current floor as well as elevators.
+ * Processes sensor data recorded in the {@link SensorFusion} class to compute live Pedestrian Dead Reckoning (PDR) estimates.
+ * <p>
+ * This class computes the user’s position based on detected steps and heading data. It uses either an estimated stride length
+ * (calculated with the Weiberg algorithm) or a provided constant value. In addition, it computes elevation changes and attempts
+ * to determine the current floor (including detecting elevator use).
+ * </p>
+ * <p>
+ * This version integrates a Kalman Filter to smooth the stride length estimation. When sensor data is invalid,
+ * the filter will predict the current value rather than simply returning 0. Sensor data validity is checked before computation.
+ * </p>
  *
- * @author Mate Stodulka
- * @author Michal Dvorak
+ * Author: [Your Name]
  */
 public class PdrProcessing {
 
-    //region Static variables
-    // Weiberg algorithm coefficient for stride calculations
-    private static final float K = 0.364f;
-    // Number of samples (seconds) to keep as memory for elevation calculation
-    private static final int elevationSeconds = 4;
-    // Number of samples (0.01 seconds)
-    private static final int accelSamples = 100;
-    // Threshold used to detect significant movement
-    private static final float movementThreshold = 0.3f; // m/s^2
-    // Threshold under which movement is considered non-existent
-    private static final float epsilon = 0.18f;
-    //endregion
+    // -------------------- Static Variables --------------------
 
-    //region Instance variables
-    // Settings for accessing shared variables
+    // Empirical constant for the Weiberg stride length estimation algorithm.
+    private static final float K = 0.364f;
+    //Note by G02: this is override by weibergMinMax func
+    // Number of seconds for which elevation samples are stored.
+    private static final int elevationSeconds = 4;
+    // Number of acceleration samples (e.g., if sampled every 0.01 seconds, total 100 samples).
+    private static final int accelSamples = 100;
+    // Threshold for detecting significant movement (in m/s^2).
+    private static final float movementThreshold = 0.3f;
+    // Threshold below which movement is considered negligible.
+    private static final float epsilon = 0.18f;
+
+    // -------------------- Instance Variables --------------------
+
+    // SharedPreferences for configuration settings.
     private SharedPreferences settings;
 
-    // Step length
+    // Step length value.
     private float stepLength;
-    // Using manually input constants instead of estimated values
+    // Flag indicating whether to use a manually specified step length.
     private boolean useManualStep;
 
-    // Current 2D position coordinates
+    // Current 2D position coordinates (in meters); starting at (0,0).
     private float positionX;
     private float positionY;
 
-    // Vertical movement calculation
+    // Variables for vertical movement (elevation) calculation.
     private Float[] startElevationBuffer;
     private float startElevation;
     private int setupIndex = 0;
@@ -59,338 +66,346 @@ public class PdrProcessing {
     private int floorHeight;
     private int currentFloor;
 
-    // Buffer of most recent elevations calculated
+    // Circular buffers for storing recent elevation and acceleration values.
     private CircularFloatBuffer elevationList;
-
-    // Buffer for most recent directional acceleration magnitudes
     private CircularFloatBuffer verticalAccel;
     private CircularFloatBuffer horizontalAccel;
 
-    // Step sum and length aggregation variables
+    // Variables to aggregate step lengths and count the steps (for computing an average step length).
     private float sumStepLength = 0;
     private int stepCount = 0;
-    //endregion
+
+    // Kalman Filter for smoothing and predicting step length.
+    private KalmanFilter stepLengthFilter;
+
+    // -------------------- Constructor --------------------
 
     /**
-     * Public constructor for the PDR class.
-     * Takes context for variable access. Sets initial values based on settings.
+     * Constructs a new PdrProcessing instance.
      *
-     * @param context   Application context for variable access.
+     * @param context Application context for accessing configuration settings.
      */
     public PdrProcessing(Context context) {
-        // Initialise settings
+        // Initialize shared preferences.
         this.settings = PreferenceManager.getDefaultSharedPreferences(context);
-        // Check if estimate or manual values should be used
+        // Check whether manual step length values should be used.
         this.useManualStep = this.settings.getBoolean("manual_step_values", false);
-        if(useManualStep) {
+        if (useManualStep) {
             try {
-                // Retrieve manual step  length
+                // Retrieve the manual step length (stored in centimeters; convert to meters).
                 this.stepLength = this.settings.getInt("user_step_length", 75) / 100f;
             } catch (Exception e) {
-                // Invalid values - reset to defaults
+                // If an error occurs, revert to a default value.
                 this.stepLength = 0.75f;
                 this.settings.edit().putInt("user_step_length", 75).apply();
             }
-        }
-        else {
-            // Using estimated step length - set to zero
+        } else {
+            // For estimated step lengths, initialize to 0.
             this.stepLength = 0;
         }
 
-        // Initial position and elevation - starts from zero
+        // Initialize position and elevation.
         this.positionX = 0f;
         this.positionY = 0f;
         this.elevation = 0f;
 
-
-        if(this.settings.getBoolean("overwrite_constants", false)) {
-            // Capacity - pressure is read with 1Hz - store values of past 10 seconds
-            this.elevationList = new CircularFloatBuffer(Integer.parseInt(settings.getString("elevation_seconds", "4")));
-
-            // Buffer for most recent acceleration values
-            this.verticalAccel = new CircularFloatBuffer(Integer.parseInt(settings.getString("accel_samples", "4")));
-            this.horizontalAccel = new CircularFloatBuffer(Integer.parseInt(settings.getString("accel_samples", "4")));
-        }
-        else {
-            // Capacity - pressure is read with 1Hz - store values of past 10 seconds
+        // Initialize buffers for elevation and acceleration based on configuration settings.
+        if (this.settings.getBoolean("overwrite_constants", false)) {
+            this.elevationList = new CircularFloatBuffer(
+                    Integer.parseInt(settings.getString("elevation_seconds", "4")));
+            this.verticalAccel = new CircularFloatBuffer(
+                    Integer.parseInt(settings.getString("accel_samples", "4")));
+            this.horizontalAccel = new CircularFloatBuffer(
+                    Integer.parseInt(settings.getString("accel_samples", "4")));
+        } else {
             this.elevationList = new CircularFloatBuffer(elevationSeconds);
-
-            // Buffer for most recent acceleration values
             this.verticalAccel = new CircularFloatBuffer(accelSamples);
             this.horizontalAccel = new CircularFloatBuffer(accelSamples);
         }
 
-        // Distance between floors is building dependent, use manual value
+        // Floor height (in meters) is building-specific.
         this.floorHeight = settings.getInt("floor_height", 4);
-        // Array for holding initial values
+        // Initialize the start elevation buffer (to collect the first three samples).
         this.startElevationBuffer = new Float[3];
-        // Start floor - assumed to be zero
+        // Assume the starting floor is 0.
         this.currentFloor = 0;
+
+        // Initialize the Kalman Filter for step length smoothing.
+        // For example: initial estimate = 0.75 m, initial covariance = 1, process noise Q = 0.01, measurement noise R = 0.1.
+        this.stepLengthFilter = new KalmanFilter(0.75, 1, 0.01, 0.1);
     }
 
+    // -------------------- Public Methods --------------------
+
     /**
-     * Function to calculate PDR coordinates from sensor values.
-     * Should be called from the step detector sensor's event with the sensor values since the last
-     * step.
+     * Updates the PDR position based on sensor data.
      *
-     * @param currentStepEnd            relative time in milliseconds since the start of the recording.
-     * @param accelMagnitudeOvertime    recorded acceleration magnitudes since the last step.
-     * @param headingRad                heading relative to magnetic north in radians.
+     * @param currentStepEnd         The timestamp (in milliseconds) marking the end of the current step.
+     * @param accelMagnitudeOvertime A list of acceleration magnitudes recorded during the current step.
+     * @param headingRad             The heading (in radians) relative to magnetic north.
+     * @return A float array containing the updated [X, Y] position in meters.
      */
     public float[] updatePdr(long currentStepEnd, List<Double> accelMagnitudeOvertime, float headingRad) {
+        // Adjust the heading so that 0 radians points east.
+        float adaptedHeading = (float) (Math.PI / 2 - headingRad);
 
-        // Change angle so zero rad is east
-        float adaptedHeading = (float) (Math.PI/2 - headingRad);
-
-        // Calculate step length
-        if(!useManualStep) {
-            //ArrayList<Double> accelMagnitudeFiltered = filter(accelMagnitudeOvertime);
-            // Estimate stride
+        // Compute the step length. If not using a manual step length, estimate it from sensor data.
+        if (!useManualStep) {
             this.stepLength = weibergMinMax(accelMagnitudeOvertime);
-            // System.err.println("Step Length" + stepLength);
         }
 
-        // Increment aggregate variables
+        // Aggregate the step length and increment the step count (for later computing an average).
         sumStepLength += stepLength;
         stepCount++;
 
-        // Translate to cartesian coordinate system
+        // Convert the step length to 2D displacement (polar to Cartesian conversion).
         float x = (float) (stepLength * Math.cos(adaptedHeading));
         float y = (float) (stepLength * Math.sin(adaptedHeading));
 
-        // Update position values
+        // Update the current position.
         this.positionX += x;
         this.positionY += y;
 
-        // return current position
         return new float[]{this.positionX, this.positionY};
     }
 
     /**
-     * Calculates the relative elevation compared to the start position.
-     * The start elevation is the median of the first three seconds of data to give the sensor time
-     * to settle. The sea level is irrelevant as only values relative to the initial position are
-     * reported.
+     * Updates the elevation based on an absolute altitude reading.
+     * The starting elevation is determined by taking the median of the first three altitude readings.
      *
-     * @param absoluteElevation absolute elevation in meters compared to sea level.
-     * @return                  current elevation in meters relative to the start position.
+     * @param absoluteElevation The absolute altitude in meters.
+     * @return The elevation change relative to the starting elevation (in meters).
      */
     public float updateElevation(float absoluteElevation) {
-        // Set start to median of first three values
-        if(setupIndex < 3) {
-            // Add values to buffer until it's full
+        // If still collecting initial samples, store the reading.
+        if (setupIndex < 3) {
             this.startElevationBuffer[setupIndex] = absoluteElevation;
-            // When buffer is full, find median, assign as startElevation
-            if(setupIndex == 2) {
+            if (setupIndex == 2) {
                 Arrays.sort(startElevationBuffer);
                 startElevation = startElevationBuffer[1];
             }
             this.setupIndex++;
-        }
-        else {
-            // Get relative elevation in meters
+        } else {
+            // Compute the relative elevation.
             this.elevation = absoluteElevation - startElevation;
-            // Add to buffer
             this.elevationList.putNewest(absoluteElevation);
 
-            // Check if there was floor movement
-            // Check if there is enough data to evaluate
-            if(this.elevationList.isFull()) {
-                // Check average of elevation array
+            // When the buffer is full, check if a floor change has occurred.
+            if (this.elevationList.isFull()) {
                 List<Float> elevationMemory = this.elevationList.getListCopy();
                 OptionalDouble currentAvg = elevationMemory.stream().mapToDouble(f -> f).average();
                 float finishAvg = currentAvg.isPresent() ? (float) currentAvg.getAsDouble() : 0;
-
-                // Check if we moved floor by comparing with start position
-                if(Math.abs(finishAvg - startElevation) > this.floorHeight) {
-                    // Change floors - 'floor' division
-                    this.currentFloor += (finishAvg - startElevation)/this.floorHeight;
+                if (Math.abs(finishAvg - startElevation) > this.floorHeight) {
+                    // Update the floor number based on the floor height.
+                    this.currentFloor += (finishAvg - startElevation) / this.floorHeight;
                 }
             }
-            // Return current elevation
             return elevation;
         }
-        // Keep elevation at zero if there is no calculated value
         return 0;
     }
 
     /**
-     * Uses the Weiberg Stride Length formula to calculate step length from accelerometer values.
+     * Estimates the step length using the Weiberg algorithm combined with a Kalman Filter for smoothing.
+     * When acceleration data is invalid, the Kalman Filter performs only a prediction.
      *
-     * @param accelMagnitude    magnitude of acceleration values between the last and current step.
-     * @return                  float stride length in meters.
+     * @param accelMagnitude A list of acceleration magnitudes for the current step.
+     * @return The estimated step length in meters.
      */
     private float weibergMinMax(List<Double> accelMagnitude) {
+        // Use a Float for the current measurement for compatibility with the Kalman Filter.
+        Float currentMeasurement = null;
 
-        if (accelMagnitude.isEmpty()) {
-            Log.w("PdrProcessing", "List is empty in weibergMinMax()");
-            return 0.0f;
-        }else {
-
-
-
-
+        if (accelMagnitude == null || accelMagnitude.isEmpty()) {
+            Log.w("PdrProcessing", "Invalid or empty acceleration data; Kalman filter will only perform prediction.");
+            // currentMeasurement remains null.
+        } else {
             double maxAccel = Collections.max(accelMagnitude);
             double minAccel = Collections.min(accelMagnitude);
-            float bounce = (float) Math.pow((maxAccel-minAccel), 0.25);
-            if(this.settings.getBoolean("overwrite_constants", false)) {
-                return bounce * Float.parseFloat(settings.getString("weiberg_k", "0.934")) * 2;
+            // Compute the "bounce" value as the 0.25th power of (max - min).
+            float bounce = (float) Math.pow((maxAccel - minAccel), 0.25);
+            if (this.settings.getBoolean("overwrite_constants", false)) {
+                currentMeasurement = (float) (bounce * Float.parseFloat(settings.getString("weiberg_k", "0.243")) * 2);
+            } else {
+                currentMeasurement = bounce * K * 2;
             }
-            return bounce*K*2;}
+        }
+
+        // Update the Kalman Filter: if currentMeasurement is null, the filter only performs prediction.
+        double filteredStepLength = stepLengthFilter.update(
+                currentMeasurement != null ? currentMeasurement.doubleValue() : null);
+        return (float) filteredStepLength;
     }
 
-
     /**
-     * Get the current X and Y coordinates from the PDR processing class.
-     * The coordinates are in meters, the start of the recording is the (0,0)
+     * Returns the current 2D PDR position.
      *
-     * @return  float array of size 2, with the X and Y coordinates respectively.
+     * @return A float array containing the [X, Y] coordinates (in meters).
      */
     public float[] getPDRMovement() {
-        float [] pdrPosition= new float[] {positionX,positionY};
-        return pdrPosition;
-
+        return new float[]{positionX, positionY};
     }
 
     /**
-     * Get the current elevation as calculated by the PDR class.
+     * Returns the current elevation change relative to the starting position.
      *
-     * @return  current elevation in meters, relative to the start position.
+     * @return The current elevation change (in meters).
      */
     public float getCurrentElevation() {
         return this.elevation;
     }
 
     /**
-     * Get the current floor number as estimated by the PDR class.
+     * Returns the current floor number (assuming the starting floor is 0).
      *
-     * @return current floor number, assuming start position is on level zero.
+     * @return The current floor number.
      */
     public int getCurrentFloor() {
         return this.currentFloor;
     }
 
     /**
-     * Estimates if the user is currently taking an elevator.
-     * From the gravity and gravity-removed acceleration values the magnitude of horizontal and
-     * vertical acceleration is calculated and stored over time. Averaging these values and
-     * comparing with the thresholds set for this class, it estimates if the current movement
-     * matches what is expected from an elevator ride.
+     * Estimates whether the user is in an elevator based on horizontal and vertical acceleration values.
      *
-     * @param gravity   array of size three, strength of gravity along the phone's x-y-z axis.
-     * @param acc       array of size three, acceleration other than gravity detected by the phone.
-     * @return          boolean true if currently in an elevator, false otherwise.
+     * @param gravity The gravity vector (x, y, z) from the sensor.
+     * @param acc     The acceleration vector (x, y, z) with gravity removed.
+     * @return True if the movement pattern indicates an elevator; otherwise, false.
      */
     public boolean estimateElevator(float[] gravity, float[] acc) {
-        // Standard gravity
         float g = SensorManager.STANDARD_GRAVITY;
-        // get horizontal and vertical acceleration magnitude
+        // Calculate the vertical acceleration magnitude.
         float verticalAcc = (float) Math.sqrt(
-                Math.pow((acc[0] * gravity[0]/g),2) +
-                Math.pow((acc[1] * gravity[1]/g), 2) +
-                Math.pow((acc[2] * gravity[2]/g), 2));
+                Math.pow((acc[0] * gravity[0] / g), 2) +
+                        Math.pow((acc[1] * gravity[1] / g), 2) +
+                        Math.pow((acc[2] * gravity[2] / g), 2));
+        // Calculate the horizontal acceleration magnitude.
         float horizontalAcc = (float) Math.sqrt(
-                Math.pow((acc[0] * (1 - gravity[0]/g)), 2) +
-                Math.pow((acc[1] * (1 - gravity[1]/g)), 2) +
-                Math.pow((acc[2] * (1 - gravity[2]/g)), 2));
-        // Save into buffer to compare with past values
+                Math.pow((acc[0] * (1 - gravity[0] / g)), 2) +
+                        Math.pow((acc[1] * (1 - gravity[1] / g)), 2) +
+                        Math.pow((acc[2] * (1 - gravity[2] / g)), 2));
+
         this.verticalAccel.putNewest(verticalAcc);
         this.horizontalAccel.putNewest(horizontalAcc);
-        // Once buffer is full, evaluate data
-        if(this.verticalAccel.isFull() && this.horizontalAccel.isFull()) {
 
-            // calculate average vertical accel
+        if (this.verticalAccel.isFull() && this.horizontalAccel.isFull()) {
             List<Float> verticalMemory = this.verticalAccel.getListCopy();
             OptionalDouble optVerticalAvg = verticalMemory.stream().mapToDouble(Math::abs).average();
             float verticalAvg = optVerticalAvg.isPresent() ? (float) optVerticalAvg.getAsDouble() : 0;
 
-
-            // calculate average horizontal accel
             List<Float> horizontalMemory = this.horizontalAccel.getListCopy();
             OptionalDouble optHorizontalAvg = horizontalMemory.stream().mapToDouble(Math::abs).average();
             float horizontalAvg = optHorizontalAvg.isPresent() ? (float) optHorizontalAvg.getAsDouble() : 0;
 
-            //System.err.println("LIFT: Vertical: " + verticalAvg);
-            //System.err.println("LIFT: Horizontal: " + horizontalAvg);
-
-            if(this.settings.getBoolean("overwrite_constants", false)) {
+            if (this.settings.getBoolean("overwrite_constants", false)) {
                 float eps = Float.parseFloat(settings.getString("epsilon", "0.18"));
                 return horizontalAvg < eps && verticalAvg > movementThreshold;
             }
-            // Check if there is minimal horizontal and significant vertical movement
             return horizontalAvg < epsilon && verticalAvg > movementThreshold;
         }
         return false;
-
     }
 
     /**
-     * Resets all values stored in the PDR function and re-initialises all buffers.
-     * Used to reset to zero position and remove existing history.
+     * Resets all stored data in the PDR processor and reinitializes variables and the Kalman Filter.
      */
     public void resetPDR() {
-        // Check if estimate or manual values should be used
         this.useManualStep = this.settings.getBoolean("manual_step_values", false);
-        if(useManualStep) {
+        if (useManualStep) {
             try {
-                // Retrieve manual step  length
                 this.stepLength = this.settings.getInt("user_step_length", 75) / 100f;
             } catch (Exception e) {
-                // Invalid values - reset to defaults
                 this.stepLength = 0.75f;
                 this.settings.edit().putInt("user_step_length", 75).apply();
             }
-        }
-        else {
-            // Using estimated step length - set to zero
+        } else {
             this.stepLength = 0;
         }
 
-        // Initial position and elevation - starts from zero
         this.positionX = 0f;
         this.positionY = 0f;
         this.elevation = 0f;
 
-        if(this.settings.getBoolean("overwrite_constants", false)) {
-            // Capacity - pressure is read with 1Hz - store values of past 10 seconds
-            this.elevationList = new CircularFloatBuffer(Integer.parseInt(settings.getString("elevation_seconds", "4")));
-
-            // Buffer for most recent acceleration values
-            this.verticalAccel = new CircularFloatBuffer(Integer.parseInt(settings.getString("accel_samples", "4")));
-            this.horizontalAccel = new CircularFloatBuffer(Integer.parseInt(settings.getString("accel_samples", "4")));
-        }
-        else {
-            // Capacity - pressure is read with 1Hz - store values of past 10 seconds
+        if (this.settings.getBoolean("overwrite_constants", false)) {
+            this.elevationList = new CircularFloatBuffer(
+                    Integer.parseInt(settings.getString("elevation_seconds", "4")));
+            this.verticalAccel = new CircularFloatBuffer(
+                    Integer.parseInt(settings.getString("accel_samples", "4")));
+            this.horizontalAccel = new CircularFloatBuffer(
+                    Integer.parseInt(settings.getString("accel_samples", "4")));
+        } else {
             this.elevationList = new CircularFloatBuffer(elevationSeconds);
-
-            // Buffer for most recent acceleration values
             this.verticalAccel = new CircularFloatBuffer(accelSamples);
             this.horizontalAccel = new CircularFloatBuffer(accelSamples);
         }
 
-        // Distance between floors is building dependent, use manual value
         this.floorHeight = settings.getInt("floor_height", 4);
-        // Array for holding initial values
         this.startElevationBuffer = new Float[3];
-        // Start floor - assumed to be zero
         this.currentFloor = 0;
+
+        // Reinitialize the Kalman Filter.
+        this.stepLengthFilter = new KalmanFilter(0.75, 1, 0.01, 0.1);
     }
 
     /**
-     * Getter for the average step length calculated from the aggregated distance and step count.
+     * Returns the average step length computed from the aggregated step lengths.
      *
-     * @return  average step length in meters.
+     * @return The average step length in meters.
      */
-    public float getAverageStepLength(){
-        //Calculate average step length
-        float averageStepLength = sumStepLength/(float) stepCount;
-
-        //Reset sum and number of steps
+    public float getAverageStepLength() {
+        float averageStepLength = sumStepLength / (float) stepCount;
         stepCount = 0;
         sumStepLength = 0;
-
-        //Return average step length
         return averageStepLength;
     }
 
+    // -------------------- Kalman Filter Implementation --------------------
+
+    /**
+     * A simple one-dimensional Kalman Filter used to smooth and predict continuous variables (e.g., step length).
+     */
+    public class KalmanFilter {
+        // Current state estimate (e.g., step length).
+        private double x;
+        // Current state covariance.
+        private double p;
+        // Process noise covariance.
+        private final double q;
+        // Measurement noise covariance.
+        private final double r;
+
+        /**
+         * Constructs a Kalman Filter.
+         *
+         * @param initX Initial state estimate.
+         * @param initP Initial covariance.
+         * @param q     Process noise covariance.
+         * @param r     Measurement noise covariance.
+         */
+        public KalmanFilter(double initX, double initP, double q, double r) {
+            this.x = initX;
+            this.p = initP;
+            this.q = q;
+            this.r = r;
+        }
+
+        /**
+         * Updates the Kalman Filter with a new measurement.
+         *
+         * @param measurement The new measurement. If null, only the prediction step is performed.
+         * @return The updated state estimate.
+         */
+        public double update(Double measurement) {
+            // Prediction step: assume state remains constant; increase covariance by process noise.
+            p = p + q;
+
+            if (measurement != null && !Double.isNaN(measurement)) {
+                double k = p / (p + r);  // Compute the Kalman gain.
+                x = x + k * (measurement - x);
+                p = (1 - k) * p;
+            } else {
+                Log.w("KalmanFilter", "Invalid measurement; performing prediction only.");
+            }
+            return x;
+        }
+    }
 }

--- a/secrets.properties
+++ b/secrets.properties
@@ -1,6 +1,6 @@
 #
 # Modify the variables to set your keys
 #
-MAPS_API_KEY=<your Google maps API key>
-OPENPOSITIONING_API_KEY=<your openpositioning user API key>
-OPENPOSITIONING_MASTER_KEY=<The openpositioning master key>
+MAPS_API_KEY=AIzaSyBp-w7jRqL59xCrtb3Zc5Ha2SkRSXy7rso
+OPENPOSITIONING_API_KEY=9U9Dfn0KkcL4qANzGc0XUw
+OPENPOSITIONING_MASTER_KEY=ewireless


### PR DESCRIPTION
CN：
加了卡尔曼滤波器根据之前的数据推测当前accelMagnitude，只在accelMagnitude回报为null或者是accelMagnitude.isEmpty() true的时候介入。

**需要对卡尔曼滤波器精调（Q和R）**

**weiberg算法的K默认值太大，导致估算步长过长。考虑加入校准**

EN:

A Kalman filter was added to predict the current accelMagnitude based on previous data, intervening only when accelMagnitude returns null or when accelMagnitude.isEmpty() is true.

**The Kalman filter needs fine-tuning (Q and R).**

**The default K value in the Weiberg algorithm is too high, resulting in an overestimated step length. Consider adding calibration.**
