### PR TITLE
fixed wgs84 conversion equation

### DIFF
--- a/app/src/main/java/com/openpositioning/PositionMe/utils/UtilFunctions.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/utils/UtilFunctions.java
@@ -39,8 +39,9 @@ public class UtilFunctions {
     public static LatLng calculateNewPos(LatLng initialLocation,float[] pdrMoved){
         // Changes Euclidean movement into maps latitude and longitude as per WGS84 datum
         double newLatitude=initialLocation.latitude+(pdrMoved[1]/(DEGREE_IN_M));
-        double newLongitude=initialLocation.longitude+(pdrMoved[0]/(DEGREE_IN_M))
-                *Math.cos(Math.toRadians(initialLocation.latitude));
+        double newLongitude = initialLocation.longitude + (
+                pdrMoved[0] / (DEGREE_IN_M * Math.cos(Math.toRadians(initialLocation.latitude)))
+        );
         return new LatLng(newLatitude, newLongitude);
     }
     /**


### PR DESCRIPTION
In the `calculateNewPos()` method of `UtilFunctions` class.

The constant *DEGREE_IN_M* should be adjusted by $$\times \cos(\phi)$$ — since as latitude ($$\phi$$) increases, the longitudinal distance per degree decreases proportionally to cos(φ).

In the original code:

`double newLongitude=initialLocation.longitude+(pdrMoved[0]/(DEGREE_IN_M))*Math.cos(Math.toRadians(initialLocation.latitude));` 

the brackets were misplaced, applying the correction as: *DEGREE_IN_M*$$\div \cos(\phi)$$.
This is incorrect and results in overcompensation at higher latitudes, causing a substantial amount of translation error.

This pull request corrects the equation by properly applying the cosine adjustment in the denominator. The updated code ensures the correction factor is applied as intended.